### PR TITLE
implemented expression tree traversal and value computation

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -49,5 +49,10 @@ pub enum ParseError {
 /// an Error during code execution.
 #[derive(Debug, Error)]
 pub enum RuntimeError {
-
+    #[error("Runtime Error: Operand must be a number.")]
+    NumberOperand,
+    #[error("Runtime Error: Incompatible types.")]
+    IncompatibleTypes,
+    #[error("Runtime Error: Unknown error.")]
+    Unknown,
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,14 +1,23 @@
 // External dependencies
+use anyhow::Result;
 use std::fmt::Display;
 
 // Internal dependencies
+use crate::errors::RuntimeError;
 use crate::token::Token;
-use crate::literal::Literal;
+use crate::token::TokenType;
+use crate::value::Value;
 
+/// The Expression is a construct, that holds a linked
+/// AST of non-terminal expressions and terminal expressions.
+/// Non-terminal expressions can hold other expressions, which
+/// finally hold terminal expressions at the leaves of the tree.
+/// The expression tree (AST) can be traversed recursively to
+/// produce values.
 #[derive(Debug, PartialEq)]
-pub enum Expression { // I <3 Rust enums
+pub enum Expression {
+    // I <3 Rust enums
     // Non-Terminals
-
     /// 0: left, 1: operator, 2: right
     Binary(Box<Expression>, Token, Box<Expression>),
     /// 0: expr
@@ -17,15 +26,124 @@ pub enum Expression { // I <3 Rust enums
     Unary(Token, Box<Expression>),
 
     // Terminals
-
     /// 0: value
-    Literal(Literal),
+    Literal(Value),
 }
 
-impl Display for Expression {
+impl Expression {
+    /// Interprets an expression and all of it's sub-expressions
+    /// and returns the computed value to the caller
+    pub fn interpret(self) -> Result<Value> {
+        match self {
+            Self::Literal(val) => Ok(val),
+            Self::Grouping(expr) => expr.interpret(),
+            Self::Unary(op, right) => handle_unary(op, right),
+            Self::Binary(left, op, right) => handle_binary(left, op, right),
+        }
+    }
+}
+
+/// Handles unary expression interpreting
+fn handle_unary(operator: Token, right: Box<Expression>) -> Result<Value> {
+    let right_val = right.interpret()?;
+
+    match operator.token_type() {
+        TokenType::Minus => Ok(Value::Number(-get_number_operand(right_val)?)), // Negation of a number
+        TokenType::Bang => Ok(Value::Bool(!is_truthy(right_val))), // Negation of a boolean expression
+        _ => Err(RuntimeError::Unknown.into()), // Shouldn't be reached :)
+    }
+}
+
+/// Handles binary expression interpreting
+fn handle_binary(left: Box<Expression>, operator: Token, right: Box<Expression>) -> Result<Value> {
+    let left_val = left.interpret()?;
+    let right_val = right.interpret()?;
+
+    match operator.token_type() {
+        // Arithmetic binary expressions
+        TokenType::Minus => Ok(Value::Number(
+            get_number_operand(left_val)? - get_number_operand(right_val)?, // Subtraction
+        )),
+        TokenType::Slash => Ok(Value::Number(
+            get_number_operand(left_val)? / get_number_operand(right_val)?, // Division
+        )),
+        TokenType::Star => Ok(Value::Number(
+            get_number_operand(left_val)? * get_number_operand(right_val)?, // Multiplication
+        )),
+        TokenType::Plus => {
+            // If both expressions (left and right) are numbers, we want an addition
+            if let Value::Number(left_num) = left_val {
+                if let Value::Number(right_num) = right_val {
+                    return Ok(Value::Number(left_num + right_num));
+                }
+            }
+            // If both are strings, we want a string concatenation
+            if let Value::String(left_str) = left_val {
+                if let Value::String(right_str) = right_val {
+                    return Ok(Value::String(String::from(left_str + &right_str)));
+                }
+            }
+            // If both don't match up, we want an error
+            Err(RuntimeError::IncompatibleTypes.into())
+        }
+
+        // Comparison binary expressions
+        TokenType::Greater => Ok(Value::Bool(
+            get_number_operand(left_val)? > get_number_operand(right_val)?, // Greater
+        )),
+        TokenType::GreaterEqual => Ok(Value::Bool(
+            get_number_operand(left_val)? >= get_number_operand(right_val)?, // Greater or Equal
+        )),
+        TokenType::Less => Ok(Value::Bool(
+            get_number_operand(left_val)? < get_number_operand(right_val)?, // Less than
+        )),
+        TokenType::LessEqual => Ok(Value::Bool(
+            get_number_operand(left_val)? <= get_number_operand(right_val)?, // Less than or Equal
+        )),
+
+        // Equality binary expressions
+        TokenType::BangEqual => Ok(Value::Bool(!is_equal(left_val, right_val))), // Not equal
+        TokenType::EqualEqual => Ok(Value::Bool(is_equal(left_val, right_val))), // Equal
+
+        _ => Err(RuntimeError::Unknown.into()), // Shouldn't be reached :)
+    }
+}
+
+/// Checks if a value is *truthy*
+fn is_truthy(value: Value) -> bool {
+    !(value == Value::Nil || value == Value::Bool(false))
+}
+
+/// Checks if two values are *equal* to eachother.
+/// Works seamlessly because Value derives the
+/// `PartialEq` trait.
+fn is_equal(first: Value, second: Value) -> bool {
+    if first == Value::Nil && second == Value::Nil {
+        return true;
+    }
+    if first == Value::Nil {
+        return false;
+    }
+
+    first == second
+}
+
+/// Checks if the given value is a Number value and if so,
+/// it returns it
+fn get_number_operand(value: Value) -> Result<f64> {
+    match value {
+        Value::Number(num) => Ok(num),
+        _ => Err(RuntimeError::NumberOperand.into()),
+    }
+}
+
+
+impl Display for Expression { // recursive printing of expressions
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Expression::Binary(left, operator, right) => write!(f, "({} {} {})", operator.lexeme(), left, right),
+            Expression::Binary(left, operator, right) => {
+                write!(f, "({} {} {})", operator.lexeme(), left, right)
+            }
             Expression::Grouping(expr) => write!(f, "(group {})", expr),
             Expression::Literal(value) => write!(f, "{}", value),
             Expression::Unary(operator, right) => write!(f, "({} {})", operator.lexeme(), right),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,16 +4,13 @@ use std::io::Write;
 
 // Internal dependencies
 use crate::errors::*;
-use crate::expression::*;
-use crate::token::*;
-use crate::literal::*;
 
 // Modules
 mod errors;
 mod expression;
 mod scanner;
 mod token;
-mod literal;
+mod value;
 mod parser;
 
 /// Takes in command line arguments and decides whether to run
@@ -70,12 +67,14 @@ fn run_prompt() -> Result<()> {
 /// process on it.
 fn run(source: String) -> Result<()> {
 
-    // -123 * (45.67)
-
     let tokens = scanner::scan_tokens(source)?; // Convert source code into tokens
     let expression = parser::parse(tokens)?;    // Convert tokens into syntax tree
 
     println!("{}", expression);
+
+    let value = expression.interpret()?;
+
+    println!("{}", value);
 
     Ok(())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,23 +4,22 @@ use anyhow::Result;
 // Internal dependencies
 use crate::errors::ParseError;
 use crate::expression::Expression;
-use crate::literal::Literal;
+use crate::value::Value;
 use crate::token::Token;
 use crate::token::TokenType;
 
-// WARNING: PARSER NOT DONE, DOES NOT REPORT SYNTAX ERRORS, BUT
-// PROPAGATES AN ERROR WHEN THE FIRST ONE IS ENCOUNTERED!
-// ONLY FOR TESTING!
-
+/// The only public function of the parser module that is the interface
+/// between the main module (or some other higher level module) and the
+/// whole parsing process. It takes in a collection of tokens and spits
+/// out an Expression, that represents the AST formed by the tokens.
 pub fn parse(tokens: Vec<Token>) -> Result<Expression> {
     let mut parser = Parser::new(tokens);
     parser.expression() // No propagation needed, because parser returns a Result
 }
 
-// ----------CONTINUE HERE-----------
-// Parser now works, but code is not very readable and redundant
-// Apply match and check functions from the book
-
+/// The Parser is a contraption that holds a collection of
+/// Tokens, traverses through them one by one and returns an
+/// AST of expressions.
 struct Parser {
     tokens: Vec<Token>,
     current: usize,
@@ -114,11 +113,11 @@ impl Parser {
     // Highest level of precedence
     fn primary(&mut self) -> Result<Expression> {
         if self.match_token_types([TokenType::False])? {
-            return Ok(Expression::Literal(Literal::Bool(false))); // creating already existing literal, fuck it
+            return Ok(Expression::Literal(Value::Bool(false))); // creating already existing literal, fuck it
         } else if self.match_token_types([TokenType::True])? {
-            return Ok(Expression::Literal(Literal::Bool(true)));
+            return Ok(Expression::Literal(Value::Bool(true)));
         } else if self.match_token_types([TokenType::Nil])? {
-            return Ok(Expression::Literal(Literal::Nil));
+            return Ok(Expression::Literal(Value::Nil));
         } else if self.match_token_types([TokenType::String, TokenType::Number])? {
             return Ok(Expression::Literal(
                 self.previous()?

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 
 // Internal dependencies
-use crate::literal::Literal;
+use crate::value::Value;
 use crate::token::{Token, TokenType};
 use crate::errors::ScanError;
 
@@ -195,7 +195,7 @@ impl Scanner {
     }
 
     /// Adds a `Token` to the token vector with a literal
-    fn add_token_literal(&mut self, token_type: TokenType, literal: Literal) -> Result<()> {
+    fn add_token_with_literal(&mut self, token_type: TokenType, literal: Value) -> Result<()> {
         let lexeme_text = self.get_lexeme_text()?;
         let token = Token::new(token_type, lexeme_text, Some(literal), self.line as u32);
         self.tokens.push(token);
@@ -243,7 +243,7 @@ impl Scanner {
             .get((self.start + 1)..(self.current - 1))
             .ok_or(ScanError::CharacterAccessError(self.line))?
             .to_string(); // Text between ""
-        self.add_token_literal(TokenType::String, Literal::String(value))
+        self.add_token_with_literal(TokenType::String, Value::String(value))
     }
 
     /// Gets called when scan_tokens encounters a digit character, so the
@@ -268,7 +268,7 @@ impl Scanner {
         let lexeme = self.get_lexeme_text()?;
         let value = lexeme.parse::<f64>()?;
 
-        self.add_token_literal(TokenType::Number, Literal::Number(value))
+        self.add_token_with_literal(TokenType::Number, Value::Number(value))
     }
 
     fn handle_identifier(&mut self) -> Result<()> {
@@ -282,9 +282,9 @@ impl Scanner {
         // If it's neither, it's just an identifier.
         match match_keyword(&text) {
             Some(token_type) => match token_type {
-                TokenType::True => self.add_token_literal(token_type, Literal::Bool(true)),
-                TokenType::False => self.add_token_literal(token_type, Literal::Bool(false)),
-                TokenType::Nil => self.add_token_literal(token_type, Literal::Nil),
+                TokenType::True => self.add_token_with_literal(token_type, Value::Bool(true)),
+                TokenType::False => self.add_token_with_literal(token_type, Value::Bool(false)),
+                TokenType::Nil => self.add_token_with_literal(token_type, Value::Nil),
                 _ => self.add_token(token_type),
             },
             None => self.add_token(TokenType::Identifier),
@@ -332,7 +332,7 @@ mod tests {
         let cmp_token = Token::new(
             TokenType::String,
             "\"Hello, World!\"".to_string(),
-            Some(Literal::String("Hello, World!".to_string())),
+            Some(Value::String("Hello, World!".to_string())),
             1,
         );
         assert_eq!(*tokens.get(1).unwrap(), cmp_token);
@@ -358,7 +358,7 @@ mod tests {
         let cmp_token = Token::new(TokenType::Equal, "=".to_string(), None, 1);
         assert_eq!(*tokens.get(2).unwrap(), cmp_token);
 
-        let cmp_token = Token::new(TokenType::True, "true".to_string(), Some(Literal::Bool(true)), 1);
+        let cmp_token = Token::new(TokenType::True, "true".to_string(), Some(Value::Bool(true)), 1);
         assert_eq!(*tokens.get(3).unwrap(), cmp_token);
 
         let cmp_token = Token::new(TokenType::Semicolon, ";".to_string(), None, 1);
@@ -415,7 +415,7 @@ mod tests {
         let cmp_token = Token::new(
             TokenType::Number,
             "123".to_string(),
-            Some(Literal::Number(123.0)),
+            Some(Value::Number(123.0)),
             1,
         );
         assert_eq!(*tokens.get(0).unwrap(), cmp_token);
@@ -423,7 +423,7 @@ mod tests {
         let cmp_token = Token::new(
             TokenType::Number,
             "45.67".to_string(),
-            Some(Literal::Number(45.67)),
+            Some(Value::Number(45.67)),
             1,
         );
         assert_eq!(*tokens.get(1).unwrap(), cmp_token);
@@ -440,7 +440,7 @@ mod tests {
         let cmp_token = Token::new(
             TokenType::String,
             "\"Hello, World!\"".to_string(),
-            Some(Literal::String("Hello, World!".to_string())),
+            Some(Value::String("Hello, World!".to_string())),
             1,
         );
         assert_eq!(*tokens.get(0).unwrap(), cmp_token);
@@ -466,7 +466,7 @@ mod tests {
         let cmp_token = Token::new(
             TokenType::Number,
             "42".to_string(),
-            Some(Literal::Number(42.0)),
+            Some(Value::Number(42.0)),
             2,
         );
         assert_eq!(*tokens.get(3).unwrap(), cmp_token);

--- a/src/token.rs
+++ b/src/token.rs
@@ -2,7 +2,7 @@
 use std::fmt::{Debug, Display};
 
 // Internal dependencies
-use crate::literal::Literal;
+use crate::value::Value;
 
 /// A Token is a piece of String that is parsed from the source code.
 /// It gives it it's meaning.
@@ -10,7 +10,7 @@ use crate::literal::Literal;
 pub struct Token {
     token_type: TokenType,
     lexeme: String,
-    literal: Option<Literal>, // Literals can be hold directly inside the Token
+    literal: Option<Value>, // Literals can be hold directly inside the Token
     line: u32,
 }
 
@@ -18,7 +18,7 @@ impl Token {
     pub fn new(
         token_type: TokenType,
         lexeme: String,
-        literal: Option<Literal>,
+        literal: Option<Value>,
         line: u32,
     ) -> Self {
         Self {
@@ -39,12 +39,8 @@ impl Token {
         self.lexeme.clone()
     }
 
-    pub fn literal(&self) -> Option<Literal> {
+    pub fn literal(&self) -> Option<Value> {
         self.literal.clone()
-    }
-
-    pub fn line(&self) -> u32 {
-        self.line
     }
 }
 
@@ -76,6 +72,7 @@ pub enum TokenType {
     And, Class, Else, False, Fun, For, If, Nil, Or,
     Print, Return, Super, This, True, Var, While,
 
+    // End of file
     Eof,
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -4,14 +4,14 @@ use std::fmt::Display;
 /// There are two different literal types: String literals and Number literals.
 /// Those can be represented using the Literal enum.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Literal {
+pub enum Value {
     String(String),
     Number(f64),
     Bool(bool),
     Nil,
 }
 
-impl Display for Literal {
+impl Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::String(s) => write!(f, "{}", s), // just the string


### PR DESCRIPTION
 Changed literal to value, so that the Value enum can hold all types of Lox's data